### PR TITLE
Update jquery.jsontotable.js

### DIFF
--- a/src/jquery.jsontotable.js
+++ b/src/jquery.jsontotable.js
@@ -1,51 +1,58 @@
 (function ($) {
-    $.jsontotable = function(data, options) {
-        var settings = $.extend({
-            id: null, // target element id
-            header: true,
-            className: null,
-        }, options);
+	$.jsontotable = function(data, options) {
+		var settings = $.extend({
+			id: null, // target element id
+			header: true,
+			className: null,
+		}, options);
 
-        options = $.extend(settings, options);
+		options = $.extend(settings, options);
 
-        var obj = data;
-        if(typeof obj === "string") {
-            obj = $.parseJSON(obj);
-        }
+		var obj = data;
+		if(typeof obj === "string") {
+			obj = $.parseJSON(obj);
+		}
 
-        if(options.id && obj.length) {
+		if(options.id && obj.length) {
 
-            var i, row;
-            var table = $("<table></table>");
+			var i, row;
+			var table = $("<table></table>");
 
-            if(options.className) {
-                table.addClass(options.className);
-            }
+			if(options.className) {
+				table.addClass(options.className);
+			}
 
-            $.fn.appendTr = function(rowData, isHeader) {
-                var frameTag = (isHeader) ? "thead" : "tbody";
-                var rowTag = (isHeader) ? "th" : "td";
+			$.fn.appendTr = function(rowData, isHeader) {
+				var frameTag = (isHeader) ? "thead" : "tbody";
+				var rowTag = (isHeader) ? "th" : "td";
 
-                row = $("<tr></tr>");
-                for(var key in rowData) {
-                    row.append("<" + rowTag + ">" + rowData[key] + "</" + rowTag + ">");
-                }
+				row = $("<tr></tr>");
+				for(var key in rowData) {
+					if(typeof rowData[key] !== "function"){ /* ADDED: this wrapper to account for people bootstrapping the ECMA Array model otherwise functions get converted to strings and show up in the object list / output */
+						row.append("<" + rowTag + ">" + rowData[key] + "</" + rowTag + ">");
+					}
+				}
 
-                $(this).append($("<" + frameTag + "></" + frameTag + ">").append(row));
-                return this;
-            };
+				if(isHeader){ /* ADDED: IF/ELSE to eliminate repetitive TBODY tags for every row */
+					$(this).append($("<" + frameTag + "></" + frameTag + ">").append(row).append("<tbody></tbody>"));
+				}else{
+					$(this).find("tbody").append(row); //always append data rows to the first tbody tag
+				}
 
-            if(options.header) {
-                table.appendTr(obj[0], true);
-            }
+				return this;
+			};
 
-            for (i = 0; i < obj.length; i++) {
-                table.appendTr(obj[i]);
-            }
+			if(options.header) {
+				table.appendTr(obj[0], true);
+			}
 
-            $(options.id).append(table);
-        }
+			for (i = options.header ? 1 : 0; i < obj.length; i++) { /* MODIFIED: options.header ? 1 : 0 --- to eliminate duplicating header as the first row of data */
+				table.appendTr(obj[i], false, i);
+			}
 
-        return this;
-    };
+			$(options.id).append(table);
+		}
+
+		return this;
+	};
 }(jQuery));


### PR DESCRIPTION
*Added a wrapper to account for people who bootstrap the Javascript Array and then end up seeing function output in the table cells.
*Added conditional logic to eliminate TBODY from being repeated for every TR
*Modified the script where appendTr() is used to append rows so that the header row is not repeated in the body of the table when options.header==true
